### PR TITLE
Changes to allow localisation/overwriting strings

### DIFF
--- a/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingErrorTextAttribute.cs
+++ b/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingErrorTextAttribute.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Reflection;
+using System.Resources;
+using System.Globalization;
 
 namespace GovUkDesignSystem.Attributes.DataBinding
 {
@@ -8,5 +11,19 @@ namespace GovUkDesignSystem.Attributes.DataBinding
     [AttributeUsage(AttributeTargets.Property, Inherited = true)]
     public abstract class GovUkDataBindingErrorTextAttribute : Attribute
     {
+        private ResourceManager _resourceManager = null;
+        protected Type ResourceType { get; set; }
+        
+        protected string ResourceName { get; set; }
+
+        protected string GetResourceValue(string resourceKey)
+        {
+            if (ResourceType != null && Assembly.GetAssembly(ResourceType) != null)
+            {
+                _resourceManager ??= new ResourceManager(ResourceName, Assembly.GetAssembly(ResourceType));
+            }
+            
+            return _resourceManager.GetString(resourceKey, CultureInfo.CurrentCulture) ?? resourceKey;
+        }
     }
 }

--- a/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingMandatoryDecimalErrorTextAttribute.cs
+++ b/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingMandatoryDecimalErrorTextAttribute.cs
@@ -4,18 +4,28 @@ namespace GovUkDesignSystem.Attributes.DataBinding
 {
     public class GovUkDataBindingMandatoryDecimalErrorTextAttribute : GovUkDataBindingErrorTextAttribute
     {
-        public GovUkDataBindingMandatoryDecimalErrorTextAttribute(string errorMessageIfMissing, string nameAtStartOfSentence)
+        public GovUkDataBindingMandatoryDecimalErrorTextAttribute(string errorMessageIfMissing, string nameAtStartOfSentence = "", Type resourceType = null, string resourceName = "", string mustBeNumberErrorMessage = "")
         {
-            if (string.IsNullOrEmpty(nameAtStartOfSentence))
+            if(string.IsNullOrEmpty(nameAtStartOfSentence) && (string.IsNullOrEmpty(mustBeNumberErrorMessage)))
             {
-                throw new ArgumentNullException("nameAtStartOfSentence cannot be null or empty");
+                throw new ArgumentNullException("nameAtStartOfSentence cannot be null or empty unless all error messages are overidden");
             }
+            
+            if (resourceType == null ^ string.IsNullOrEmpty(resourceName))
+            {
+                throw new ArgumentNullException("resourceName or resourceType cannot be null or empty while the other is not null or empty");
+            }
+            
             if(string.IsNullOrEmpty(errorMessageIfMissing))
             {
                 throw new ArgumentNullException("errorMessageIfMissing cannot be null or empty");
             }
+            
             NameAtStartOfSentence = nameAtStartOfSentence;
             ErrorMessageIfMissing = errorMessageIfMissing;
+            MustBeNumberErrorMessage = mustBeNumberErrorMessage;
+            ResourceType = resourceType;
+            ResourceName = resourceName;
         }
 
         /// <summary>
@@ -29,6 +39,23 @@ namespace GovUkDesignSystem.Attributes.DataBinding
         /// A complete sentence of the form: ‘Enter [whatever it is]’.
         /// <br/>For example, ‘Enter your first name’.
         /// </summary>
-        public string ErrorMessageIfMissing { get; private set; }
+        private string _errorMessageIfMissing;
+        public string ErrorMessageIfMissing
+        {
+            get => GetResourceValue(_errorMessageIfMissing);
+            private set => _errorMessageIfMissing = value;
+        }
+        
+        /// <summary>
+        /// An override for the error message that is displayed if the value entered is not a number.
+        /// A complete sentence of the form: ‘[Whatever it is] must be a number’
+        /// <br/>e.g. "Median age must be a number"
+        /// </summary>
+        private string _mustBeNumberErrorMessage;
+        public string MustBeNumberErrorMessage
+        {
+            get => GetResourceValue(_mustBeNumberErrorMessage);
+            private set => _mustBeNumberErrorMessage = value;
+        }
     }
 }

--- a/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingMandatoryIntErrorTextAttribute.cs
+++ b/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingMandatoryIntErrorTextAttribute.cs
@@ -1,23 +1,59 @@
 ﻿using System;
 
+
 namespace GovUkDesignSystem.Attributes.DataBinding
 {
     public class GovUkDataBindingMandatoryIntErrorTextAttribute : GovUkDataBindingErrorTextAttribute
     {
-        public GovUkDataBindingMandatoryIntErrorTextAttribute(string errorMessageIfMissing, string nameAtStartOfSentence)
+        public GovUkDataBindingMandatoryIntErrorTextAttribute(string errorMessageIfMissing, string nameAtStartOfSentence = "", Type resourceType = null, string resourceName = "", string isWholeNumberErrorMessage = "", string mustBeNumberErrorMessage = "")
         {
-            if(string.IsNullOrEmpty(nameAtStartOfSentence))
+            if(string.IsNullOrEmpty(nameAtStartOfSentence) && (string.IsNullOrEmpty(isWholeNumberErrorMessage) || string.IsNullOrEmpty(mustBeNumberErrorMessage)))
             {
-                throw new ArgumentNullException("nameAtStartOfSentence cannot be null or empty");
+                throw new ArgumentNullException("nameAtStartOfSentence cannot be null or empty unless all error messages are overidden");
             }
+
+            if (resourceType == null ^ string.IsNullOrEmpty(resourceName))
+            {
+                throw new ArgumentNullException("resourceName or resourceType cannot be null or empty while the other is not null or empty");
+            }
+            
             if(string.IsNullOrEmpty(errorMessageIfMissing))
             {
                 throw new ArgumentNullException("errorMessageIfMissing cannot be null or empty");
             }
+            
             NameAtStartOfSentence = nameAtStartOfSentence;
             ErrorMessageIfMissing = errorMessageIfMissing;
+            MustBeNumberErrorMessage = mustBeNumberErrorMessage;
+            IsWholeNumberErrorMessage = isWholeNumberErrorMessage;
+            ResourceType = resourceType;
+            ResourceName = resourceName;
         }
 
+        /// <summary>
+        /// An override for the error message that is displayed if the value entered is not a whole number.
+        /// A complete sentence of the form: ‘[Whatever it is] must be a whole number’
+        /// <br/>e.g. "Median age must be a whole number"
+        /// </summary>
+        private string _isWholeNumberErrorMessage;
+        public string IsWholeNumberErrorMessage
+        {
+            get => GetResourceValue(_isWholeNumberErrorMessage);
+            private set => _isWholeNumberErrorMessage = value;
+        }
+        
+        /// <summary>
+        /// An override for the error message that is displayed if the value entered is not a number.
+        /// A complete sentence of the form: ‘[Whatever it is] must be a number’
+        /// <br/>e.g. "Median age must be a number"
+        /// </summary>
+        private string _mustBeNumberErrorMessage;
+        public string MustBeNumberErrorMessage
+        {
+            get => GetResourceValue(_mustBeNumberErrorMessage);
+            private set => _mustBeNumberErrorMessage = value;
+        }
+        
         /// <summary>
         /// The name as it would appear at the start of a sentence
         /// <br/>e.g. "[Full name] must be 2 characters or more"
@@ -29,6 +65,11 @@ namespace GovUkDesignSystem.Attributes.DataBinding
         /// A complete sentence of the form: ‘Enter [whatever it is]’.
         /// <br/>For example, ‘Enter your first name’.
         /// </summary>
-        public string ErrorMessageIfMissing { get; private set; }
+        private string _errorMessageIfMissing;
+        public string ErrorMessageIfMissing
+        {
+            get => GetResourceValue(_errorMessageIfMissing);
+            private set => _errorMessageIfMissing = value;
+        }
     }
 }

--- a/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingOptionalDecimalErrorTextAttribute.cs
+++ b/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingOptionalDecimalErrorTextAttribute.cs
@@ -4,15 +4,35 @@ namespace GovUkDesignSystem.Attributes.DataBinding
 {
     public class GovUkDataBindingOptionalDecimalErrorTextAttribute : GovUkDataBindingErrorTextAttribute
     {
-        public GovUkDataBindingOptionalDecimalErrorTextAttribute(string nameAtStartOfSentence)
+        public GovUkDataBindingOptionalDecimalErrorTextAttribute(string nameAtStartOfSentence = "", Type resourceType = null, string resourceName = "", string mustBeNumberErrorMessage = "")
         {
+            if (resourceType == null ^ string.IsNullOrEmpty(resourceName))
+            {
+                throw new ArgumentNullException("resourceName or resourceType cannot be null or empty while the other is not null or empty");
+            }
+            
             if (string.IsNullOrEmpty(nameAtStartOfSentence))
             {
                 throw new ArgumentNullException("nameAtStartOfSentence cannot be null or empty");
             }
             NameAtStartOfSentence = nameAtStartOfSentence;
+            MustBeNumberErrorMessage = mustBeNumberErrorMessage;
+            ResourceType = resourceType;
+            ResourceName = resourceName;
         }
-
+                
+        /// <summary>
+        /// An override for the error message that is displayed if the value entered is not a number.
+        /// A complete sentence of the form: ‘[Whatever it is] must be a number’
+        /// <br/>e.g. "Median age must be a number"
+        /// </summary>
+        private string _mustBeNumberErrorMessage;
+        public string MustBeNumberErrorMessage
+        {
+            get => GetResourceValue(_mustBeNumberErrorMessage);
+            private set => _mustBeNumberErrorMessage = value;
+        }
+        
         /// <summary>
         /// The name as it would appear at the start of a sentence
         /// <br/>e.g. "[Full name] must be 2 characters or more"

--- a/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingOptionalIntErrorTextAttribute.cs
+++ b/GovUkDesignSystem/Attributes/DataBinding/GovUkDataBindingOptionalIntErrorTextAttribute.cs
@@ -4,20 +4,65 @@ namespace GovUkDesignSystem.Attributes.DataBinding
 {
     public class GovUkDataBindingOptionalIntErrorTextAttribute : GovUkDataBindingErrorTextAttribute
     {
-        public GovUkDataBindingOptionalIntErrorTextAttribute(string nameAtStartOfSentence)
+        public GovUkDataBindingOptionalIntErrorTextAttribute(string nameAtStartOfSentence = "", Type resourceType = null, string resourceName = "", string isWholeNumberErrorMessage = "", string mustBeNumberErrorMessage = "")
         {
-            if (string.IsNullOrEmpty(nameAtStartOfSentence))
+            if(string.IsNullOrEmpty(nameAtStartOfSentence) && (string.IsNullOrEmpty(isWholeNumberErrorMessage) || string.IsNullOrEmpty(mustBeNumberErrorMessage)))
             {
-                throw new ArgumentNullException("nameAtStartOfSentence cannot be null or empty");
+                throw new ArgumentNullException("nameAtStartOfSentence cannot be null or empty unless all error messages are overidden");
             }
+            
+            if (resourceType == null ^ string.IsNullOrEmpty(resourceName))
+            {
+                throw new ArgumentNullException("resourceName or resourceType cannot be null or empty while the other is not null or empty");
+            }
+            
             NameAtStartOfSentence = nameAtStartOfSentence;
+            MustBeNumberErrorMessage = mustBeNumberErrorMessage;
+            IsWholeNumberErrorMessage = isWholeNumberErrorMessage;
+            ResourceType = resourceType;
+            ResourceName = resourceName;
         }
-
+        
+        /// <summary>
+        /// An override for the error message that is displayed if the value entered is not a whole number.
+        /// A complete sentence of the form: ‘[Whatever it is] must be a whole number’
+        /// <br/>e.g. "Median age must be a whole number"
+        /// </summary>
+        private string _isWholeNumberErrorMessage;
+        public string IsWholeNumberErrorMessage
+        {
+            get => GetResourceValue(_isWholeNumberErrorMessage);
+            private set => _isWholeNumberErrorMessage = value;
+        }
+        
+        /// <summary>
+        /// An override for the error message that is displayed if the value entered is not a number.
+        /// A complete sentence of the form: ‘[Whatever it is] must be a number’
+        /// <br/>e.g. "Median age must be a number"
+        /// </summary>
+        private string _mustBeNumberErrorMessage;
+        public string MustBeNumberErrorMessage
+        {
+            get => GetResourceValue(_mustBeNumberErrorMessage);
+            private set => _mustBeNumberErrorMessage = value;
+        }
+        
         /// <summary>
         /// The name as it would appear at the start of a sentence
         /// <br/>e.g. "[Full name] must be 2 characters or more"
         /// <br/>e.g. "[Median age] must be a number"
         /// </summary>
         public string NameAtStartOfSentence { get; private set; }
+
+        /// <summary>
+        /// A complete sentence of the form: ‘Enter [whatever it is]’.
+        /// <br/>For example, ‘Enter your first name’.
+        /// </summary>
+        private string _errorMessageIfMissing;
+        public string ErrorMessageIfMissing
+        {
+            get => GetResourceValue(_errorMessageIfMissing);
+            private set => _errorMessageIfMissing = value;
+        }
     }
 }

--- a/GovUkDesignSystem/Attributes/GovUkRadioCheckboxLabelTextAttribute.cs
+++ b/GovUkDesignSystem/Attributes/GovUkRadioCheckboxLabelTextAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 
@@ -14,8 +15,9 @@ namespace GovUkDesignSystem.Attributes
         public string Text { get; set; }
         
         /// <summary>
-        /// Returns the Text property of any GovUkRadioCheckboxLabelTextAttribute on the enum value
-        /// If no attribute exists returns enumValue.ToString()
+        /// Returns the Text property of any GovUkRadioCheckboxLabelTextAttribute on the enum value.
+        /// If no copy of this attribute exists, instead returns the value of the Display attribute.
+        /// If neither attribute exists returns enumValue.ToString()
         /// </summary>
         /// <param name="enumValue"></param>
         /// <returns></returns>
@@ -25,8 +27,9 @@ namespace GovUkDesignSystem.Attributes
                 .GetMember(enumValue.ToString())
                 .Single()
                 .GetCustomAttribute<GovUkRadioCheckboxLabelTextAttribute>();
+            string displayName = enumValue.GetType().GetMember(enumValue.ToString()).First().GetCustomAttribute<DisplayAttribute>()?.Name;
 
-            return attribute == null ? enumValue.ToString() : attribute.Text;
+            return attribute != null ? attribute.Text : displayName ?? enumValue.ToString();
         }
 
     }

--- a/GovUkDesignSystem/Attributes/GovUkRadioCheckboxLabelTextAttribute.cs
+++ b/GovUkDesignSystem/Attributes/GovUkRadioCheckboxLabelTextAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 
@@ -14,8 +15,9 @@ namespace GovUkDesignSystem.Attributes
         public string Text { get; set; }
         
         /// <summary>
-        /// Returns the Text property of any GovUkRadioCheckboxLabelTextAttribute on the enum value
-        /// If no attribute exists returns enumValue.ToString()
+        /// Returns the Text property of any GovUkRadioCheckboxLabelTextAttribute on the enum value.
+        /// If no copy of this attribute exists, instead returns the value of the Display attribute.
+        /// If neither attribute exists returns enumValue.ToString()
         /// </summary>
         /// <param name="enumValue"></param>
         /// <returns></returns>
@@ -25,8 +27,9 @@ namespace GovUkDesignSystem.Attributes
                 .GetMember(enumValue.ToString())
                 .Single()
                 .GetCustomAttribute<GovUkRadioCheckboxLabelTextAttribute>();
+            string displayName = enumValue.GetType().GetMember(enumValue.ToString()).First().GetCustomAttribute<DisplayAttribute>()?.GetDescription();
 
-            return attribute == null ? enumValue.ToString() : attribute.Text;
+            return attribute != null ? attribute.Text : displayName ?? enumValue.ToString();
         }
 
     }

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Footer.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Footer.cshtml
@@ -69,15 +69,30 @@
                     <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
                 </svg>
                 <span class="govuk-footer__licence-description">
-                    All content is available under the
-                    <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+                    @{if(Model?.FooterLicenseDescription?.Html != null)
+                      {
+                          await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model.FooterLicenseDescription);                      
+                      }
+                      else
+                      {
+                          <text>All content is available under the <a class="govuk-footer__link" href = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel = "license" > Open Government Licence v3.0 </a>, except where otherwise stated</text>
+                      }
+                    }
                 </span>
             </div>
             <div class="govuk-footer__meta-item">
                 <a class="govuk-footer__link govuk-footer__copyright-logo"
                    href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
-                    © Crown copyright
-                </a>
+                        @{if(string.IsNullOrEmpty(Model?.FooterCopyrightText?.Text))
+                          {
+                              <text>© Crown copyright</text>
+                          }
+                          else
+                          {
+                              @Model.FooterCopyrightText.Text;
+                          }
+                        }
+                    </a>
             </div>
         </div>
     </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/FooterViewModel.cs
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/FooterViewModel.cs
@@ -32,6 +32,15 @@ namespace GovUkDesignSystem.GovUkDesignSystemComponents
         /// </summary>
         public Dictionary<string, string> Attributes { get; set; }
 
+        /// <summary>
+        /// HTML override to the text in the license description, to allow for localisation.
+        /// </summary>
+        public FooterLicenseDescriptionViewModel FooterLicenseDescription { get; set; } = null;
+        
+        /// <summary>
+        /// Text override to the copyright text, to allow for localisation.
+        /// </summary>
+        public FooterCopyrightTextViewModel FooterCopyrightText { get; set; }
     }
 
     public class FooterMetaNavigationViewModel : IHtmlText
@@ -105,5 +114,34 @@ namespace GovUkDesignSystem.GovUkDesignSystemComponents
             "This doesn't work yet - The GenderPayGap.WebUI.Classes.TagHelpers.AnchorTagHelper doesn't currently allow arbitrary attributes")]
         public Dictionary<string, string> Attributes { get; set; }
 
+    }
+    
+    /// <summary>
+    /// If either the HTML or Text are specified here, they will override the default English text for the license description
+    /// </summary>
+    public class FooterLicenseDescriptionViewModel: IHtmlText
+    {
+        /// <summary>
+        ///     HTML to add to the license description in the footer
+        ///     Set this using the @&lt;text&gt;&lt;/text&gt; syntax
+        /// </summary>
+        public Func<object, object> Html { get; set; } = null;
+        
+        /// <summary>
+        ///     Text to override the licence description in the footer.
+        ///     If either the 'Html' specified, this option is ignored.
+        /// </summary>
+        public string Text { get; set; }
+    }
+
+    /// <summary>
+    /// If either the HTML or Text are specified here, they will override the default English text for copyright in the footer
+    /// </summary>
+    public class FooterCopyrightTextViewModel
+    {
+        /// <summary>
+        ///     Text to override the copyright text in the footer.
+        /// </summary>
+        public string Text { get; set; }
     }
 }

--- a/GovUkDesignSystem/GovUkHtmlHelperExtensions.cs
+++ b/GovUkDesignSystem/GovUkHtmlHelperExtensions.cs
@@ -242,12 +242,12 @@ namespace GovUkDesignSystem
         public static async Task<IHtmlContent> GovUkErrorSummary(
             this IHtmlHelper htmlHelper,
             ModelStateDictionary modelState,
-            string[] optionalOrderOfPropertyNamesInTheView = null)
+            string[] optionalOrderOfPropertyNamesInTheView = null, string errorSummaryTitle = "There is a problem")
         {
             // Give 'optionalOrderOfPropertiesInTheView' a default value (of an empty array)
             var orderOfPropertyNamesInTheView = optionalOrderOfPropertyNamesInTheView ?? new string[0];
 
-            return await ErrorSummaryHtmlGenerator.GenerateHtml(htmlHelper, modelState, orderOfPropertyNamesInTheView);
+            return await ErrorSummaryHtmlGenerator.GenerateHtml(htmlHelper, modelState, orderOfPropertyNamesInTheView, errorSummaryTitle);
         }
 
         public static async Task<IHtmlContent> GovUkFieldset(

--- a/GovUkDesignSystem/HtmlGenerators/ErrorSummaryHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/ErrorSummaryHtmlGenerator.cs
@@ -14,7 +14,7 @@ namespace GovUkDesignSystem.HtmlGenerators
         internal static async Task<IHtmlContent> GenerateHtml(
             this IHtmlHelper htmlHelper,
             ModelStateDictionary modelState,
-            string[] orderOfPropertyNamesInTheView,
+            string[] orderOfPropertyNamesInTheView, string errorSummaryTitle,
             string idPrefix = null)
         {
             if (modelState.IsValid)
@@ -38,7 +38,7 @@ namespace GovUkDesignSystem.HtmlGenerators
             {
                 Title = new ErrorSummaryTitle
                 {
-                    Text = "There is a problem"
+                    Text = errorSummaryTitle
                 },
                 Errors = errorSummaryItems
             };

--- a/GovUkDesignSystem/ModelBinders/GovUkDecimalBinderBase.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkDecimalBinderBase.cs
@@ -13,7 +13,7 @@ namespace GovUkDesignSystem.ModelBinders
         /// <summary>
         /// Try to bind the provided value to the model state. If errorMessageIfMissing is null then treat the property as optional
         /// </summary>
-        public Task BindModelBase(ModelBindingContext bindingContext, string errorMessageIfMissing, string nameAtStartOfSentence)
+        public Task BindModelBase(ModelBindingContext bindingContext, string errorMessageIfMissing, string nameAtStartOfSentence, string mustBeNumberErrorMessage = "")
         {
             var modelName = bindingContext.ModelName;
 
@@ -62,7 +62,15 @@ namespace GovUkDesignSystem.ModelBinders
             // Ensure that the value is a number
             if (!decimal.TryParse(value, out var decimalValue))
             {
-                bindingContext.ModelState.TryAddModelError(modelName, $"{nameAtStartOfSentence} must be a number");
+                if (string.IsNullOrEmpty(mustBeNumberErrorMessage))
+                {
+                    bindingContext.ModelState.TryAddModelError(modelName, $"{nameAtStartOfSentence} must be a number");
+                }
+                else
+                {
+                    bindingContext.ModelState.TryAddModelError(modelName, mustBeNumberErrorMessage);
+                }
+
                 return Task.CompletedTask;
             }
 

--- a/GovUkDesignSystem/ModelBinders/GovUkIntBinderBase.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkIntBinderBase.cs
@@ -13,7 +13,7 @@ namespace GovUkDesignSystem.ModelBinders
         /// <summary>
         /// Try to bind the provided value to the model state. If errorMessageIfMissing is null then treat the property as optional
         /// </summary>
-        public Task BindModelBase(ModelBindingContext bindingContext, string errorMessageIfMissing, string nameAtStartOfSentence)
+        public Task BindModelBase(ModelBindingContext bindingContext, string errorMessageIfMissing, string nameAtStartOfSentence, string mustBeNumberErrorMessage = "", string isWholeNumberErrorMessage = "")
         {
             var modelName = bindingContext.ModelName;
 
@@ -62,14 +62,29 @@ namespace GovUkDesignSystem.ModelBinders
             // Ensure that the value is a number
             if (!double.TryParse(value, out _))
             {
-                bindingContext.ModelState.TryAddModelError(modelName, $"{nameAtStartOfSentence} must be a number");
+                if (string.IsNullOrEmpty(mustBeNumberErrorMessage))
+                {
+                    bindingContext.ModelState.TryAddModelError(modelName, $"{nameAtStartOfSentence} must be a number");
+                }
+                else
+                {
+                    bindingContext.ModelState.TryAddModelError(modelName, mustBeNumberErrorMessage);
+                }
                 return Task.CompletedTask;
             }
 
             //Ensure that the value is an integer
             if (!int.TryParse(value, out var intValue))
             {
-                bindingContext.ModelState.TryAddModelError(modelName, $"{nameAtStartOfSentence} must be a whole number");
+                if (string.IsNullOrEmpty(isWholeNumberErrorMessage))
+                {
+                    bindingContext.ModelState.TryAddModelError(modelName, $"{nameAtStartOfSentence} must be a whole number");
+                }
+                else
+                {
+                    bindingContext.ModelState.TryAddModelError(modelName, isWholeNumberErrorMessage);
+                }
+
                 return Task.CompletedTask;
             }
 

--- a/GovUkDesignSystem/ModelBinders/GovUkMandatoryDecimalBinder.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkMandatoryDecimalBinder.cs
@@ -21,7 +21,7 @@ namespace GovUkDesignSystem.ModelBinders
                 throw new Exception("When using the GovUkMandatoryDecimalBinder you must also provide a GovUkDataBindingMandatoryDecimalErrorTextAttribute attribute and ensure that you register GovUkDataBindingErrorTextProvider in your application's Startup.ConfigureServices method.");
             }
 
-            return BindModelBase(bindingContext, errorTextAttribute.ErrorMessageIfMissing, errorTextAttribute.NameAtStartOfSentence);
+            return BindModelBase(bindingContext, errorTextAttribute.ErrorMessageIfMissing, errorTextAttribute.NameAtStartOfSentence, errorTextAttribute.MustBeNumberErrorMessage);
         }
 
     }

--- a/GovUkDesignSystem/ModelBinders/GovUkMandatoryIntBinder.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkMandatoryIntBinder.cs
@@ -21,7 +21,7 @@ namespace GovUkDesignSystem.ModelBinders
                 throw new Exception("When using the GovUkMandatoryIntBinder you must also provide a GovUkDataBindingMandatoryIntErrorTextAttribute attribute and ensure that you register GovUkDataBindingErrorTextProvider in your application's Startup.ConfigureServices method.");
             }
 
-            return BindModelBase(bindingContext, errorTextAttribute.ErrorMessageIfMissing, errorTextAttribute.NameAtStartOfSentence);
+            return BindModelBase(bindingContext, errorTextAttribute.ErrorMessageIfMissing, errorTextAttribute.NameAtStartOfSentence, errorTextAttribute.MustBeNumberErrorMessage, errorTextAttribute.IsWholeNumberErrorMessage);
         }
     }
 }

--- a/GovUkDesignSystem/ModelBinders/GovUkOptionalDecimalBinder.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkOptionalDecimalBinder.cs
@@ -21,7 +21,7 @@ namespace GovUkDesignSystem.ModelBinders
                 throw new Exception("When using the GovUkOptionalDecimalBinder you must also provide a GovUkDataBindingOptionalDecimalErrorTextAttribute attribute and ensure that you register GovUkDataBindingErrorTextProvider in your application's Startup.ConfigureServices method.");
             }
 
-            return BindModelBase(bindingContext, null, errorTextAttribute.NameAtStartOfSentence);
+            return BindModelBase(bindingContext, null, errorTextAttribute.NameAtStartOfSentence, errorTextAttribute.MustBeNumberErrorMessage);
         }
     }
 }

--- a/GovUkDesignSystem/ModelBinders/GovUkOptionalIntBinder.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkOptionalIntBinder.cs
@@ -20,8 +20,8 @@ namespace GovUkDesignSystem.ModelBinders
             {
                 throw new Exception("When using the GovUkOptionalIntBinder you must also provide a GovUkDataBindingOptionalIntErrorTextAttribute attribute and ensure that you register GovUkDataBindingErrorTextProvider in your application's Startup.ConfigureServices method.");
             }
-
-            return BindModelBase(bindingContext, null, errorTextAttribute.NameAtStartOfSentence);
+            
+            return BindModelBase(bindingContext, null, errorTextAttribute.NameAtStartOfSentence, errorTextAttribute.MustBeNumberErrorMessage, errorTextAttribute.IsWholeNumberErrorMessage);
         }
     }
 }


### PR DESCRIPTION
This provides the ability to override (and localise) strings in the following areas:

1. The labels shown next to a radio buttons
2. The "There is a problem" text from the error summary
3. The strings from the data binding error text (all types, excluding date)
4. The license text, and copyright text in the footer

Where possible, original functionality is preserved when there is no overwriting.